### PR TITLE
Correct header for Press Brief (1/6/15)

### DIFF
--- a/2015/01/05/press-brief.txt
+++ b/2015/01/05/press-brief.txt
@@ -1,4 +1,4 @@
-# Secretary Josh Earnest James S. Brady Press Briefing Room
+# Press Briefing by Press Secretary Josh Earnest, 1/5/2015
 # Text Source: http://www.whitehouse.gov/the-press-office/2015/01/05/press-briefing-press-secretary-josh-earnest
 # Video Source: https://www.youtube.com/watch?v=gQTM07xPouA
 


### PR DESCRIPTION
The header didn't make a ton of sense, so this commit alters it to
match the format used by the Press Brief from 1/5/15.